### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/glitzereinhorn270487/firefly/security/code-scanning/1](https://github.com/glitzereinhorn270487/firefly/security/code-scanning/1)

The problem can be addressed by explicitly declaring a `permissions` block at the root of the workflow. This sets the minimum required permissions for all jobs (unless overridden), thereby preventing unintentional privilege escalation via the default repository/organization settings. In most CI workflows running builds and tests, only read access to the repository contents is needed unless the workflow specifically creates issues, releases, or pull requests. The minimal and recommended fix is to add `permissions: contents: read` right after the workflow `name:` block and before `on:`. No further action is necessary unless a job or step requires elevated or additional permissions. This does not change functionality but hardens security.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
